### PR TITLE
Replace `File.exists?` with `File.exist?`.  `File.exists?` is deprecated in Ruby 2.7 and removed in Ruby 3.2.

### DIFF
--- a/ext/rb_tuntap_ext/rb_tuntap_ext.c
+++ b/ext/rb_tuntap_ext/rb_tuntap_ext.c
@@ -62,7 +62,7 @@ static VALUE device_initialize(VALUE self,
   }
 
   /* Validate dev */
-  /* Easier to do in Ruby e.g. File.exists?(dev) */
+  /* Easier to do in Ruby e.g. File.exist?(dev) */
 
   rb_iv_set(self, "@name" , name);
   rb_iv_set(self, "@type" , type);

--- a/lib/rb_tuntap.rb
+++ b/lib/rb_tuntap.rb
@@ -25,7 +25,7 @@ module RbTunTap
       [ '/dev/net/tun',
         '/dev/tun',
       ].each do |f|
-        return f if File.exists?(f) # and File.readable?(f)
+        return f if File.exist?(f) # and File.readable?(f)
       end
     end
 


### PR DESCRIPTION
https://ruby-doc.org/2.7.7/File.html#method-c-exists-3F