### PR TITLE
Throw exception when unable to determine tun device

### DIFF
--- a/lib/rb_tuntap.rb
+++ b/lib/rb_tuntap.rb
@@ -27,6 +27,8 @@ module RbTunTap
       ].each do |f|
         return f if File.exists?(f) # and File.readable?(f)
       end
+
+      raise('Unable to detect tun device file')
     end
 
     def addr=(address)


### PR DESCRIPTION
Otherwise you get a rather obtuse `TypeError: wrong argument type Array (expected String)` from `lib/rb_tuntap.rb:120`